### PR TITLE
Implement combined modal/amodal dataloading as an option

### DIFF
--- a/test.py
+++ b/test.py
@@ -102,6 +102,15 @@ def test(data,
         img = img.to(device, non_blocking=True)
         img = img.half() if half else img.float()  # uint8 to fp16/32
         img /= 255.0  # 0 - 255 to 0.0 - 1.0
+
+        """
+        In the modal/amodal use case, 'targets' is a dictionary of tensors, so you should choose
+        targets['modal'] or targets['amodal'] depending on your needs.
+        """
+        # TODO: change this logic when ready!
+        if isinstance(targets, dict):
+            targets = targets['amodal']
+
         targets = targets.to(device)
         nb, _, height, width = img.shape  # batch size, channels, height, width
 
@@ -306,6 +315,11 @@ if __name__ == '__main__':
     parser.add_argument('--project', default='runs/test', help='save to project/name')
     parser.add_argument('--name', default='exp', help='save to project/name')
     parser.add_argument('--exist-ok', action='store_true', help='existing project/name ok, do not increment')
+
+    # custom
+    parser.add_argument('--label-suffix', type=str, default='',
+                        help='a suffix of interest to append to the target label path. Can be useful to avoid rearranging data.')
+
     opt = parser.parse_args()
     opt.save_json |= opt.data.endswith('coco.yaml')
     opt.data = check_file(opt.data)  # check file

--- a/utils/ScanState.py
+++ b/utils/ScanState.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class ScanState(Enum):
+    """
+    An enum describing the possible outcomes when scanning an individual file in the dataset.
+    """
+    FOUND = 1
+    EMPTY = 2
+    MISSING = 3
+    CORRUPTED = 4

--- a/utils/general.py
+++ b/utils/general.py
@@ -267,6 +267,11 @@ def colorstr(*input):
 
 
 def labels_to_class_weights(labels, nc=80):
+
+    if isinstance(labels[0], dict):
+        # if in modal/amodal use case, use amodal labels (end-result network output targets) to determine class weights
+        labels = [labels[i]['amodal'] for i in range(len(labels))]
+
     # Get class weights (inverse frequency) from training labels
     if labels[0] is None:  # no labels loaded
         return torch.Tensor()
@@ -286,6 +291,11 @@ def labels_to_class_weights(labels, nc=80):
 
 
 def labels_to_image_weights(labels, nc=80, class_weights=np.ones(80)):
+
+    if isinstance(labels[0], dict):
+        # if in modal/amodal use case, use amodal labels (end-result network output targets) to determine class counts
+        labels = [labels[i]['amodal'] for i in range(len(labels))]
+
     # Produces image weights based on class_weights and image contents
     class_counts = np.array([np.bincount(x[:, 0].astype(np.int), minlength=nc) for x in labels])
     image_weights = (class_weights.reshape(1, nc) * class_counts).sum(1)


### PR DESCRIPTION
When a directory containing modal/amodal labels is specified in a data yaml file, this option is automatically used.

These changes are somewhat hacky (organizationally, at least)r and the time needed to actually restructure the code to make this a 'first-class feature' was not budgeted for this commit.