### PR TITLE
Vectorize pixel map computation

### DIFF
--- a/utils/feature_utils.py
+++ b/utils/feature_utils.py
@@ -2,7 +2,7 @@ import torch
 from typing import Tuple
 
 
-DEFAULT_BOX_LIMIT = 250
+DEFAULT_BOX_LIMIT = 300
 
 
 def ground_truth_boxes_to_pixel_map(nc: int, batch_size: int, boxes: torch.Tensor, img_shape: Tuple[int, int]) -> torch.Tensor:


### PR DESCRIPTION
If this is too slow/using too much memory, we can consider downsampling and then upsampling (e.g., generating pixel maps of 320x320 instead of 640x640). We shouldn't lose too much information this way.